### PR TITLE
Fix missing strncasecmp on Windows

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -46,6 +46,10 @@
 #include "strbuf.h"
 #include "fpconv.h"
 
+#if defined(_WIN32) || defined(_WIN64)
+#define strncasecmp _strnicmp
+#endif
+
 #ifndef CJSON_MODNAME
 #define CJSON_MODNAME   "cjson"
 #endif


### PR DESCRIPTION
As `strncasecmp` doesn't exist on Windows, we're going to macro it to `_strnicmp` if we're building on a Windows machine.